### PR TITLE
Omit internal, issue #7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 oldtest/
 .*.swp
 depscheck
+depscheck.iml
+.idea

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The `-v` flag will print more verbose info with detailed statistics:
     depscheck -v .
     depscheck -v github.com/Typeform/goblitline
 
-By default, the external packages are checked only. Use `-internal` flag in case you want to see statistics on internal and vendored packages too.
+By default, only external packages are checked. Use `-internal` flag in case you want to see statistics on internal and vendored packages too.
 
     depscheck -v -internal golang.org/x/tools/go/loader
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ The `-v` flag will print more verbose info with detailed statistics:
     depscheck -v .
     depscheck -v github.com/Typeform/goblitline
 
+By default, the external packages are checked only. Use `-internal` flag in case you want to see statistics on internal and vendored packages too.
+
+    depscheck -v -internal golang.org/x/tools/go/loader
+
 With `-stdlib` flag, *depscheck* also can analyze stdlib packages and treat them as an external dependencies. Suggestion mode is disabled with stdlib flag (stdlib is smarter than this tool), so you will probably will want `-v` flag to see how your package uses stdlib.
 
     depscheck -stdlib -v net/http

--- a/deps_test.go
+++ b/deps_test.go
@@ -10,27 +10,27 @@ func TestExportedFuncs(t *testing.T) {
 	var src string
 
 	src = "test/exported.go"
-	result = getResult(t, "test", src)
+	result = getResult(t, false, "test", src)
 	checkCount(src, t, result, 2)
 	checkSelector(src, t, result, "xsample.var.Sample", 1, 0, 0, 0, 0)
 	checkSelector(src, t, result, "xsample.func.SampleFunc", 1, 6, 14, 0, 2)
 
 	src = "test/exported2.go"
-	result = getResult(t, "test", src)
+	result = getResult(t, false, "test", src)
 	checkCount(src, t, result, 3)
 	checkSelector(src, t, result, "xsample.func.SampleFunc", 1, 6, 14, 0, 2)
 	checkSelector(src, t, result, "xsample.(Foo).method.Bar", 1, 3, 3, 0, 0)
 	checkSelector(src, t, result, "xsample.type.Foo", 1, 0, 0, 0, 0)
 
 	src = "test/pkg_renamed.go"
-	result = getResult(t, "test", src)
+	result = getResult(t, false, "test", src)
 	checkCount(src, t, result, 3)
 	checkSelector(src, t, result, "xsample.func.SampleFunc", 1, 6, 14, 0, 2)
 	checkSelector(src, t, result, "xsample.(Foo).method.Bar", 1, 3, 3, 0, 0)
 	checkSelector(src, t, result, "xsample.type.Foo", 1, 0, 0, 0, 0)
 
 	src = "test/pkg_dot.go"
-	result = getResult(t, "test", src)
+	result = getResult(t, false, "test", src)
 	checkCount(src, t, result, 3)
 	checkSelector(src, t, result, "xsample.func.SampleFunc", 1, 6, 14, 0, 2)
 	checkSelector(src, t, result, "xsample.(Foo).method.Bar", 1, 3, 3, 0, 0)
@@ -42,7 +42,7 @@ func TestRecursion(t *testing.T) {
 	var src string
 
 	src = "test/recursion.go"
-	result = getResult(t, "test", src)
+	result = getResult(t, false, "test", src)
 	checkCount(src, t, result, 2)
 	checkSelector(src, t, result, "bar.func.Bar", 1, 4, 4, 0, 0)
 	checkSelector(src, t, result, "foo.func.Foo", 1, 4, 8, 1, 0)
@@ -53,7 +53,7 @@ func TestConsts(t *testing.T) {
 	var src string
 
 	src = "test/const.go"
-	result = getResult(t, "test", src)
+	result = getResult(t, false, "test", src)
 	checkCount(src, t, result, 1)
 	checkSelector(src, t, result, "foo.const.FooConst", 1, 0, 0, 0, 0)
 }
@@ -63,7 +63,7 @@ func TestVars(t *testing.T) {
 	var src string
 
 	src = "test/var.go"
-	result = getResult(t, "test", src)
+	result = getResult(t, false, "test", src)
 	checkCount(src, t, result, 1)
 	checkSelector(src, t, result, "foo.var.FooVar", 1, 0, 0, 0, 0)
 }
@@ -73,13 +73,36 @@ func TestInterface(t *testing.T) {
 	var src string
 
 	src = "test/interface.go"
-	result = getResult(t, "test", src)
+	result = getResult(t, false, "test", src)
 	checkCount(src, t, result, 2)
 	checkSelector(src, t, result, "foo.(Fooer).method.Foo", 1, 0, 0, 0, 0)
 	checkSelector(src, t, result, "foo.interface.Fooer", 1, 0, 0, 0, 0)
 }
 
-func getResult(t *testing.T, name string, sources ...string) *Result {
+func TestInternal(t *testing.T) {
+	var result *Result
+	var src string
+
+	src = "test/recursion.go"
+	result = getResult(t, false, "github.com/divan/depscheck/test", src)
+	checkCount(src, t, result, 0)
+	result = getResult(t, true, "github.com/divan/depscheck/test", src)
+	checkCount(src, t, result, 2)
+
+	src = "test/pkg_renamed.go"
+	result = getResult(t, false, "github.com/divan/depscheck/test", src)
+	checkCount(src, t, result, 0)
+	result = getResult(t, true, "github.com/divan/depscheck/test", src)
+	checkCount(src, t, result, 3)
+
+	src = "test/external.go"
+	result = getResult(t, false, "github.com/divan/depscheck/test", src)
+	checkCount(src, t, result, 1)
+	result = getResult(t, true, "github.com/divan/depscheck/test", src)
+	checkCount(src, t, result, 2)
+}
+
+func getResult(t *testing.T, isInternal bool, name string, sources ...string) *Result {
 	var conf loader.Config
 	conf.CreateFromFilenames(name, sources...)
 	p, err := conf.Load()
@@ -87,7 +110,7 @@ func getResult(t *testing.T, name string, sources ...string) *Result {
 		t.Fatal(err)
 	}
 
-	w := NewWalker(p, false, false)
+	w := NewWalker(p, false, isInternal)
 	return w.TopWalk()
 }
 
@@ -95,7 +118,6 @@ func checkCount(src string, t *testing.T, r *Result, want int) {
 	if have := len(r.Counter); have != want {
 		t.Fatalf("%s: expected to have %d selectors, but have %d", src, want, have)
 	}
-
 }
 
 func checkSelector(src string, t *testing.T, r *Result, fn string, count, loc, loccum, depth, depthint int) {

--- a/deps_test.go
+++ b/deps_test.go
@@ -87,7 +87,7 @@ func getResult(t *testing.T, name string, sources ...string) *Result {
 		t.Fatal(err)
 	}
 
-	w := NewWalker(p, false)
+	w := NewWalker(p, false, false)
 	return w.TopWalk()
 }
 

--- a/internal.go
+++ b/internal.go
@@ -3,13 +3,13 @@ package main
 import "strings"
 
 func IsInternal(pkg, subpkg string) bool {
-	//Skip if any is stdlib
+	// Skip if any is stdlib
 	if IsStdlib(pkg) || IsStdlib(subpkg) {
 		return false
 	}
 
 	// Or it is submodule
-	if strings.HasPrefix(subpkg, pkg) {
+	if strings.HasPrefix(subpkg, pkg + "/") {
 		return true
 	}
 

--- a/internal.go
+++ b/internal.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"strings"
+)
+
+func IsInternal(pkg, subpkg string) bool {
+//	fmt.Printf("\n\n%s\n%s\n-----------\n", pkg, subpkg)
+	//Skip if any is stdlib
+	if IsStdlib(pkg) || IsStdlib(subpkg) {
+		return false
+	}
+
+	// Or it is submodule
+	if strings.HasPrefix(subpkg, pkg) {
+		return true
+	}
+
+	// Or it is on same nesting level
+	if i := strings.LastIndex(pkg, "/"); i > 0 {
+//		fmt.Printf("%s\n==================\n\n", pkg[0:i])
+		if strings.HasPrefix(subpkg, pkg[0:i]) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal.go
+++ b/internal.go
@@ -1,11 +1,8 @@
 package main
 
-import (
-	"strings"
-)
+import "strings"
 
 func IsInternal(pkg, subpkg string) bool {
-//	fmt.Printf("\n\n%s\n%s\n-----------\n", pkg, subpkg)
 	//Skip if any is stdlib
 	if IsStdlib(pkg) || IsStdlib(subpkg) {
 		return false
@@ -18,10 +15,10 @@ func IsInternal(pkg, subpkg string) bool {
 
 	// Or it is on same nesting level
 	if i := strings.LastIndex(pkg, "/"); i > 0 {
-//		fmt.Printf("%s\n==================\n\n", pkg[0:i])
 		if strings.HasPrefix(subpkg, pkg[0:i]) {
 			return true
 		}
 	}
+	
 	return false
 }

--- a/main.go
+++ b/main.go
@@ -9,10 +9,11 @@ import (
 )
 
 var (
-	stdlib  = flag.Bool("stdlib", false, "Treat stdlib packages as external dependencies")
-	tests   = flag.Bool("tests", false, "Include tests for deps analysis")
-	verbose = flag.Bool("v", false, "Be verbose and print whole deps info table")
-	totals  = flag.Bool("totalonly", false, "Print only totals stats")
+	stdlib   = flag.Bool("stdlib", false, "Treat stdlib packages as external dependencies")
+	tests    = flag.Bool("tests", false, "Include tests for deps analysis")
+	verbose  = flag.Bool("v", false, "Be verbose and print whole deps info table")
+	totals   = flag.Bool("totalonly", false, "Print only totals stats")
+	internal = flag.Bool("internal", false, "Include intertanl packages analysis")
 )
 
 func main() {
@@ -28,7 +29,7 @@ func main() {
 		return
 	}
 
-	w := NewWalker(p, *stdlib)
+	w := NewWalker(p, *stdlib, *internal)
 
 	result := w.TopWalk()
 

--- a/test/external.go
+++ b/test/external.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"github.com/divan/depscheck/test/foo"
+	"golang.org/x/tools/go/loader"
+)
+
+func main() {
+	x := foo.FooConst
+	var l loader.Config
+	fmt.Println(x, l)
+}

--- a/walker.go
+++ b/walker.go
@@ -28,10 +28,10 @@ func NewWalker(p *loader.Program, stdlib, internal bool) *Walker {
 		// prepare map of resolved imports
 		for _, i := range pkg.Pkg.Imports() {
 
-			if !internal && IsInternal(pkg.Pkg.Path(), i.Path()) {
+			if !stdlib && IsStdlib(i.Path()) {
 				continue
 			}
-			if !stdlib && IsStdlib(i.Path()) {
+			if !internal && IsInternal(pkg.Pkg.Path(), i.Path()) {
 				continue
 			}
 			packages[i.Name()] = NewPackage(i.Name(), i.Path())


### PR DESCRIPTION
Now default behaviour omits internal packages from checking. I suppose the internal, is the package(s) that placed on same level with checked or nested below.

Also I've updated `Readme.md` and `tests` to fit the new functionality.
